### PR TITLE
Fixing TS1016 when using TypeScript on package `superdilithium`

### DIFF
--- a/packages/superdilithium/index.d.ts
+++ b/packages/superdilithium/index.d.ts
@@ -102,7 +102,7 @@ declare module 'superdilithium' {
 			},
 			additionalData?: Uint8Array|string,
 			knownGoodHash?: Uint8Array|string,
-			includeHash: true
+			includeHash?: boolean
 		) : Promise<{
 			hash: Uint8Array;
 			message: Uint8Array;
@@ -126,7 +126,7 @@ declare module 'superdilithium' {
 			},
 			additionalData?: Uint8Array|string,
 			knownGoodHash?: Uint8Array|string,
-			includeHash: true
+			includeHash?: boolean
 		) : Promise<{
 			hash: string;
 			message: Uint8Array;
@@ -182,7 +182,7 @@ declare module 'superdilithium' {
 			},
 			additionalData?: Uint8Array|string,
 			knownGoodHash?: Uint8Array|string,
-			includeHash: true
+			includeHash?: boolean
 		) : Promise<{
 			hash: Uint8Array;
 			valid: boolean;


### PR DESCRIPTION
```
node_modules/superdilithium/index.d.ts:105:4 - error TS1016: A required parameter cannot follow an optional parameter.

105    includeHash: true
       ~~~~~~~~~~~

node_modules/superdilithium/index.d.ts:129:4 - error TS1016: A required parameter cannot follow an optional parameter.

129    includeHash: true
       ~~~~~~~~~~~

node_modules/superdilithium/index.d.ts:185:4 - error TS1016: A required parameter cannot follow an optional parameter.

185    includeHash: true
       ~~~~~~~~~~~


Found 3 errors in the same file, starting at: node_modules/superdilithium/index.d.ts:105
```

So I changed it to be
```ts
includeHash?: boolean
```
instead since that's what it supposed to be.